### PR TITLE
Add packages required to build an appimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM centos:7
 
 RUN yum -y install centos-release-scl epel-release && \
     yum -y install bzip2 clang-analyzer cloc cmake cmake3 cppcheck devtoolset-6 doxygen findutils gcc gcc-c++ git graphviz \
-        libpcap-devel lcov make mpich-3.2-devel python2-pip python-dev rh-python35 valgrind vim-common autoconf automake libtool perl && \
+        libpcap-devel lcov make mpich-3.2-devel python2-pip python-dev rh-python35 valgrind vim-common autoconf automake \
+        libtool perl fuse fuse-libs fuseiso gvfs-fuse dkms dkms-fuse squashfs-tools && \
     yum -y autoremove && \
     yum clean all
 
@@ -27,8 +28,9 @@ RUN git clone https://github.com/ess-dmsc/build-utils.git && \
     scl enable devtoolset-6 -- make install
 
 RUN adduser jenkins
-
 RUN chown -R jenkins $CONAN_USER_HOME/.conan
+RUN groupadd fuse
+RUN usermod -a -G fuse jenkins
 
 USER jenkins
 


### PR DESCRIPTION
To use fuse the container would still have to use the fuse kernel module from the host, and be run with these flags: `--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined`. This is obviously not ideal, but I guess it is no less secure than the Mac and Windows build jobs.