### PR TITLE
Install cyrus SASL development libraries

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ properties([
   disableConcurrentBuilds(abortPrevious: true)
 ])
 
-imageVersion = '7.0.0'
+imageVersion = '7.1.0'
 
 imageName = "dockerregistry.esss.dk/ecdc_group/build-node-images/centos7-build-node:${imageVersion}"
 

--- a/files/packages.yml
+++ b/files/packages.yml
@@ -7,6 +7,7 @@ yum_packages:
   - cloc
   - cmake3
   - cppcheck
+  - cyrus-sasl-devel
   - devtoolset-8
   - devtoolset-11
   - dkms


### PR DESCRIPTION
To build kafka-to-nexus with SASL SCRAM support we enabled both SSL and SASL compile options to librdkafka.
Cyrus SASL devel libraries are required to build librdkafka with the SASL flag.